### PR TITLE
add cloudpickle to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,4 @@ torch==1.13.1
 typing-extensions==4.4.0
 urllib3==1.26.14
 virtualenv==20.20.0
+cloudpickle==3.0.0


### PR DESCRIPTION
had to install cloudpickle manually when installing with python3.8 under Conda virtual env.

# PR Type (Fix)

## Short Description
Installed kscope via PyPI in cluster with `python=3.8` under a Conda virtual env. 
Upon `import scope` I got `Module Not Found` error for `cloudpickle`.

It seems like this lib should be added under requirements.txt